### PR TITLE
2020-07-07 创建docker network后结束运行

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # go-micro-ci-daemon
 基于Golang开发的微CI工具（守护程序）
 
+## 2020-07-07 创建docker network后结束运行
+1. 如果DOCKER网络被创建则：docker run的时候需使用--network=network参数进行重启
+2. 第一次启动daemon容器时，不要带入--network参数，否则可能因为不在一个虚拟网络中导致daemon无法注册的问题
+
 ## 2020-07-07 自动部署thirdServices
 1. 统一服务注册类型(当前新增支持consul)
     ```yaml

--- a/docker/utils.go
+++ b/docker/utils.go
@@ -22,10 +22,10 @@ func GetDockerVersion() (string, error) {
 	}
 }
 
-func EnsureNetworkMode(networkMode, driver string) error {
+func EnsureNetworkMode(networkMode, driver string) (created bool, err error) {
 	dockerClient, err := client.NewEnvClient()
 	if nil != err {
-		return err
+		return false, err
 	}
 
 	filterArgs := filters.NewArgs()
@@ -33,18 +33,18 @@ func EnsureNetworkMode(networkMode, driver string) error {
 	if r, err := dockerClient.NetworkList(context.Background(), types.NetworkListOptions{
 		Filters: filterArgs,
 	}); nil != err {
-		return err
+		return false, err
 	} else if len(r) > 0 {
 		if strings.Compare(r[0].Driver, driver) != 0 {
-			return fmt.Errorf("%s:网络驱动模式为%s, 预期为:%s", networkMode, r[0].Driver, driver)
+			return false, fmt.Errorf("%s:网络驱动模式为%s, 预期为:%s", networkMode, r[0].Driver, driver)
 		}
 	} else if _, err := dockerClient.NetworkCreate(context.Background(), networkMode, types.NetworkCreate{
 		Driver: driver,
 	}); nil != err {
-		return err
+		return true, err
 	}
 
-	return nil
+	return false, nil
 }
 
 func DeleteImage(imageID string) error {


### PR DESCRIPTION
1. 如果DOCKER网络被创建则：docker run的时候需使用--network=network参数进行重启
2. 第一次启动daemon容器时，不要带入--network参数，否则可能因为不在一个虚拟网络中导致daemon无法注册的问题